### PR TITLE
Implement Phase 1: Variable Decoration for Concurrency Safety

### DIFF
--- a/ERROR_RECOVERY_ROADMAP.md
+++ b/ERROR_RECOVERY_ROADMAP.md
@@ -5,7 +5,7 @@ This document outlines the planned implementation steps to address the vulnerabi
 ## Phase 1: Concurrency Safety
 *Goal: Ensure thread safety between the Interrupt Service Routine (ISR) and the main loop.*
 
-- [ ] **Variable Decoration:** Mark the following members as `volatile` in `MaerklinMotorola.h`:
+- [x] **Variable Decoration:** Mark the following members as `volatile` in `MaerklinMotorola.h`:
     - `last_tm`
     - `sync`
     - `timings_pos`

--- a/MaerklinMotorola.h
+++ b/MaerklinMotorola.h
@@ -50,7 +50,7 @@ struct MaerklinMotorolaData {
   unsigned char SubAddress;
   unsigned char PortAddress; // verbose "port" address (1 to 256 / 320)
 
-  DataGramState State;
+  volatile DataGramState State;
   
   bool Function;
   bool Stop;
@@ -71,11 +71,11 @@ public:
 
 private:
   int pin;
-  unsigned long last_tm = 0;
+  volatile unsigned long last_tm = 0;
   unsigned long sync_tm = 0;
-  bool sync = false;
-  char timings_pos = 0;
-  char DataQueueWritePosition = 0;
+  volatile bool sync = false;
+  volatile char timings_pos = 0;
+  volatile char DataQueueWritePosition = 0;
   MaerklinMotorolaData DataQueue[MM_QUEUE_LENGTH];
 };
 


### PR DESCRIPTION
I have implemented the "Variable Decoration" step from Phase 1 of the `ERROR_RECOVERY_ROADMAP.md`. This involves marking key variables shared between the Interrupt Service Routine (ISR) and the main thread as `volatile` to prevent compiler optimizations that could lead to race conditions.

The following variables were updated in `MaerklinMotorola.h`:
- `MaerklinMotorolaData::State`
- `MaerklinMotorola::last_tm`
- `MaerklinMotorola::sync`
- `MaerklinMotorola::timings_pos`
- `MaerklinMotorola::DataQueueWritePosition`

I also updated `ERROR_RECOVERY_ROADMAP.md` to mark this step as complete and verified the changes by running the existing native test suite.

Fixes #22

---
*PR created automatically by Jules for task [623823918156473257](https://jules.google.com/task/623823918156473257) started by @chatelao*