### PR TITLE
Implement Buffer Overrun Protection and Diagnostic Counter

### DIFF
--- a/ERROR_RECOVERY_ROADMAP.md
+++ b/ERROR_RECOVERY_ROADMAP.md
@@ -16,8 +16,8 @@ This document outlines the planned implementation steps to address the vulnerabi
 ## Phase 2: Buffer Management
 *Goal: Prevent data corruption from queue overruns during high-traffic periods.*
 
-- [ ] **Overrun Protection in ISR:** Update `PinChange()` to check the state of the next available `DataQueue` slot. If the state is `DataGramState_ReadyToParse` or `DataGramState_Validated`, the ISR should drop the incoming frame and wait for the next sync gap.
-- [ ] **Diagnostic Counter:** Add a `volatile unsigned long overrun_count` to track how many frames were dropped due to buffer saturation.
+- [x] **Overrun Protection in ISR:** Update `PinChange()` to check the state of the next available `DataQueue` slot. If the state is `DataGramState_ReadyToParse` or `DataGramState_Validated`, the ISR should drop the incoming frame and wait for the next sync gap.
+- [x] **Diagnostic Counter:** Add a `volatile unsigned long overrun_count` to track how many frames were dropped due to buffer saturation.
 
 ## Phase 3: Signal Robustness
 *Goal: Improve noise rejection and signal stability.*

--- a/MaerklinMotorola.cpp
+++ b/MaerklinMotorola.cpp
@@ -9,10 +9,15 @@
 MaerklinMotorola::MaerklinMotorola(int p) {
   pin = p;
   DataQueueWritePosition = 0;
+  overrun_count = 0;
   sync = false;
   for(int i=0; i<MM_QUEUE_LENGTH; i++) {
     DataQueue[i].State = DataGramState_Finished;
   }
+}
+
+unsigned long MaerklinMotorola::GetOverrunCount() const {
+  return overrun_count;
 }
 
 MaerklinMotorolaData* MaerklinMotorola::GetData() {
@@ -214,14 +219,18 @@ void MaerklinMotorola::PinChange() {
 		 DataQueueWritePosition = 0;
 	  }
 	  
-	  DataQueue[DataQueueWritePosition].State = DataGramState_Reading;
       sync = false;
       timings_pos = 0;
     }
   } else {
     if(tm_delta>500) { //protocol-specific pause time
-      sync = true;
-      sync_tm = tm;
+      if(DataQueue[DataQueueWritePosition].State == DataGramState_ReadyToParse || DataQueue[DataQueueWritePosition].State == DataGramState_Validated) {
+        overrun_count++;
+      } else {
+        sync = true;
+        sync_tm = tm;
+        DataQueue[DataQueueWritePosition].State = DataGramState_Reading;
+      }
     }
   }
 

--- a/MaerklinMotorola.h
+++ b/MaerklinMotorola.h
@@ -68,6 +68,7 @@ public:
   void PinChange();
   MaerklinMotorolaData* GetData();
   void Parse();
+  unsigned long GetOverrunCount() const;
 
 private:
   int pin;
@@ -76,6 +77,7 @@ private:
   volatile bool sync = false;
   volatile char timings_pos = 0;
   volatile char DataQueueWritePosition = 0;
+  volatile unsigned long overrun_count = 0;
   MaerklinMotorolaData DataQueue[MM_QUEUE_LENGTH];
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -212,6 +212,35 @@ void test_invalid_length() {
     std::cout << "test_invalid_length passed" << std::endl;
 }
 
+void test_overrun_protection() {
+    MaerklinMotorola mm(2);
+    std::vector<int> bits(18, 0);
+    std::vector<int> timings = create_timings(bits);
+
+    // Fill the queue
+    for (int i = 0; i < MM_QUEUE_LENGTH; i++) {
+        send_packet(mm, timings);
+        // We DON'T call Parse() yet, so they stay in ReadyToParse state
+    }
+
+    // Now the queue should be full. The next packet should trigger overrun.
+    unsigned long initial_overrun = mm.GetOverrunCount();
+    send_packet(mm, timings);
+    assert(mm.GetOverrunCount() == initial_overrun + 1);
+
+    // Parse one and get it to free up a slot
+    mm.Parse();
+    MaerklinMotorolaData* data = mm.GetData();
+    assert(data != nullptr);
+
+    // Now we should be able to send another packet without overrun
+    initial_overrun = mm.GetOverrunCount();
+    send_packet(mm, timings);
+    assert(mm.GetOverrunCount() == initial_overrun);
+
+    std::cout << "test_overrun_protection passed" << std::endl;
+}
+
 int main() {
     test_mm1_loco();
     test_loco_changedir();
@@ -222,5 +251,6 @@ int main() {
     test_pinchange_resync();
     test_queue_wraparound();
     test_invalid_length();
+    test_overrun_protection();
     return 0;
 }


### PR DESCRIPTION
Implemented buffer overrun protection and a diagnostic counter for the `MaerklinMotorola` library. This change ensures that unconsumed packets in the circular buffer are not silently overwritten by the ISR. A new member `overrun_count` tracks how many frames were dropped due to buffer saturation, and a public getter is provided for external monitoring. The implementation was verified with a new native unit test and follows recommended concurrency practices for embedded systems.

Fixes #24

---
*PR created automatically by Jules for task [6804525822275082321](https://jules.google.com/task/6804525822275082321) started by @chatelao*