### PR TITLE
Implement Spike Filtering for Signal Robustness

### DIFF
--- a/ERROR_RECOVERY_ROADMAP.md
+++ b/ERROR_RECOVERY_ROADMAP.md
@@ -22,7 +22,7 @@ This document outlines the planned implementation steps to address the vulnerabi
 ## Phase 3: Signal Robustness
 *Goal: Improve noise rejection and signal stability.*
 
-- [ ] **Spike Filtering:** Implement a simple software low-pass filter in `PinChange()` to ignore pulses shorter than a minimum threshold (e.g., 20µs).
+- [x] **Spike Filtering:** Implement a simple software low-pass filter in `PinChange()` to ignore pulses shorter than a minimum threshold (e.g., 20µs).
 - [ ] **Adaptive Sync Threshold:** Instead of a hardcoded 500µs, investigate using a threshold relative to the measured bit period to improve performance on varied hardware.
 
 ## Verification Plan

--- a/MaerklinMotorola.cpp
+++ b/MaerklinMotorola.cpp
@@ -199,6 +199,10 @@ void MaerklinMotorola::PinChange() {
   unsigned long tm = micros();
   unsigned long tm_delta = tm - last_tm;
 
+  if (tm_delta < MM_MIN_PULSE_WIDTH) {
+    return;
+  }
+
   if(sync) { //collect bits only after syncronization
     DataQueue[DataQueueWritePosition].Timings[timings_pos] = int(tm_delta); //filing the time difference between the last edges
     timings_pos++;

--- a/MaerklinMotorola.h
+++ b/MaerklinMotorola.h
@@ -10,6 +10,7 @@
 #include "Arduino.h"
 
 #define MM_QUEUE_LENGTH	10
+#define MM_MIN_PULSE_WIDTH 20
 
 enum DataGramState
 {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -241,6 +241,42 @@ void test_overrun_protection() {
     std::cout << "test_overrun_protection passed" << std::endl;
 }
 
+void test_spike_filtering() {
+    MaerklinMotorola mm(2);
+    std::vector<int> bits(18, 0);
+    std::vector<int> timings = create_timings(bits);
+
+    // Normal sync
+    current_micros += 1000;
+    mm.PinChange();
+
+    // Send bits with a spike
+    for (size_t i = 0; i < timings.size(); i++) {
+        if (i == 2) { // Inject spike in the middle of a timing interval
+            current_micros += 10; // Less than MM_MIN_PULSE_WIDTH (20)
+            mm.PinChange();
+            current_micros += (timings[i] - 10);
+            mm.PinChange();
+        } else {
+            current_micros += timings[i];
+            mm.PinChange();
+        }
+    }
+
+    mm.Parse();
+    // Packet should still be parsed correctly because the spike at 10us was ignored,
+    // so the total duration for that timing interval remains timings[2].
+
+    // We need a second packet for validation
+    send_packet(mm, timings);
+    mm.Parse();
+
+    MaerklinMotorolaData* data = mm.GetData();
+    assert(data != nullptr);
+    assert(data->Address == 0);
+    std::cout << "test_spike_filtering passed" << std::endl;
+}
+
 int main() {
     test_mm1_loco();
     test_loco_changedir();
@@ -252,5 +288,6 @@ int main() {
     test_queue_wraparound();
     test_invalid_length();
     test_overrun_protection();
+    test_spike_filtering();
     return 0;
 }


### PR DESCRIPTION
Implemented a software low-pass filter (spike filtering) in the PinChange() ISR to ignore pulses shorter than 20µs. This improves the library's robustness against high-frequency noise. The change includes:
1. Header update with MM_MIN_PULSE_WIDTH.
2. ISR logic update to skip short pulses.
3. New unit test to verify the fix.
4. Updated roadmap status.

Fixes #28

---
*PR created automatically by Jules for task [430091902435066783](https://jules.google.com/task/430091902435066783) started by @chatelao*