### PR TITLE
Implement Adaptive Sync Threshold

### DIFF
--- a/ERROR_RECOVERY_ROADMAP.md
+++ b/ERROR_RECOVERY_ROADMAP.md
@@ -23,7 +23,7 @@ This document outlines the planned implementation steps to address the vulnerabi
 *Goal: Improve noise rejection and signal stability.*
 
 - [x] **Spike Filtering:** Implement a simple software low-pass filter in `PinChange()` to ignore pulses shorter than a minimum threshold (e.g., 20µs).
-- [ ] **Adaptive Sync Threshold:** Instead of a hardcoded 500µs, investigate using a threshold relative to the measured bit period to improve performance on varied hardware.
+- [x] **Adaptive Sync Threshold:** Instead of a hardcoded 500µs, the library now uses a threshold relative to the measured bit period (3x period, bounded 200-800µs) to improve performance on varied hardware.
 
 ## Verification Plan
 1. **Unit Testing:** Update the native test suite to simulate concurrent access and verify that atomic blocks prevent race conditions.

--- a/MaerklinMotorola.cpp
+++ b/MaerklinMotorola.cpp
@@ -11,6 +11,7 @@ MaerklinMotorola::MaerklinMotorola(int p) {
   DataQueueWritePosition = 0;
   overrun_count = 0;
   sync = false;
+  sync_timeout = MM_SYNC_TIMEOUT_DEFAULT;
   for(int i=0; i<MM_QUEUE_LENGTH; i++) {
     DataQueue[i].State = DataGramState_Finished;
   }
@@ -193,6 +194,14 @@ void MaerklinMotorola::Parse() {
 			}  
 		  }	
 		  if(parsed) {
+			  //Adaptive sync threshold
+			  int new_sync_timeout = period * 3;
+			  if (new_sync_timeout < 200) new_sync_timeout = 200;
+			  if (new_sync_timeout > 800) new_sync_timeout = 800;
+			  MM_ATOMIC_BLOCK {
+				  sync_timeout = new_sync_timeout;
+			  }
+
 			  //Get previous DataGram from Queue
 			  int previousDataGramPos = QueuePos > 0 ? QueuePos - 1 : MM_QUEUE_LENGTH - 1;
 			  MM_ATOMIC_BLOCK {
@@ -227,7 +236,7 @@ void MaerklinMotorola::PinChange() {
     DataQueue[DataQueueWritePosition].Timings[timings_pos] = int(tm_delta); //filing the time difference between the last edges
     timings_pos++;
 
-	if(tm_delta>500) {
+	if(tm_delta > (unsigned long)sync_timeout) {
 		//timeout - resync
 		timings_pos = 0;
 		sync = true;
@@ -247,7 +256,7 @@ void MaerklinMotorola::PinChange() {
       timings_pos = 0;
     }
   } else {
-    if(tm_delta>500) { //protocol-specific pause time
+    if(tm_delta > (unsigned long)sync_timeout) { //protocol-specific pause time
       if(DataQueue[DataQueueWritePosition].State == DataGramState_ReadyToParse || DataQueue[DataQueueWritePosition].State == DataGramState_Validated) {
         overrun_count++;
       } else {

--- a/MaerklinMotorola.h
+++ b/MaerklinMotorola.h
@@ -23,6 +23,7 @@ struct MM_AtomicGuard {
 
 #define MM_QUEUE_LENGTH	10
 #define MM_MIN_PULSE_WIDTH 20
+#define MM_SYNC_TIMEOUT_DEFAULT 500
 
 enum DataGramState
 {
@@ -91,6 +92,7 @@ private:
   volatile char timings_pos = 0;
   volatile char DataQueueWritePosition = 0;
   volatile unsigned long overrun_count = 0;
+  volatile int sync_timeout;
   MaerklinMotorolaData DataQueue[MM_QUEUE_LENGTH];
 };
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -277,6 +277,40 @@ void test_spike_filtering() {
     std::cout << "test_spike_filtering passed" << std::endl;
 }
 
+void test_adaptive_sync_threshold() {
+    MaerklinMotorola mm(2);
+    // 1. Send a magnet telegram (short period)
+    // Bit period for magnet telegram is < 150. Let's use 40+60=100.
+    std::vector<int> bits(18, 0);
+    bits[16] = 1; // MagnetState = true
+    std::vector<int> timings = create_timings(bits, 40, 60);
+
+    send_packet(mm, timings); mm.Parse();
+    send_packet(mm, timings); mm.Parse();
+    assert(mm.GetData() != nullptr);
+
+    // After this, sync_timeout should be around 100 * 3 = 300.
+
+    // 2. Try to sync with a gap shorter than 500 but longer than 300.
+    // Let's use a gap of 400.
+    current_micros += 400;
+    mm.PinChange(); // Should trigger sync because 400 > 300
+
+    // Send another packet
+    for (int t : timings) {
+        current_micros += t;
+        mm.PinChange();
+    }
+    mm.Parse();
+
+    // Send one more for validation
+    send_packet(mm, timings);
+    mm.Parse();
+
+    assert(mm.GetData() != nullptr);
+    std::cout << "test_adaptive_sync_threshold passed" << std::endl;
+}
+
 int main() {
     test_mm1_loco();
     test_loco_changedir();
@@ -289,5 +323,6 @@ int main() {
     test_invalid_length();
     test_overrun_protection();
     test_spike_filtering();
+    test_adaptive_sync_threshold();
     return 0;
 }


### PR DESCRIPTION
Implemented the "Adaptive Sync Threshold" step from the Error Recovery Roadmap. The library now adjusts its synchronization timeout based on the measured bit period of successful packets, improving robustness against varied hardware and signal timings. The implementation includes concurrency protection and thorough unit testing.

Fixes #32

---
*PR created automatically by Jules for task [1373381890854457639](https://jules.google.com/task/1373381890854457639) started by @chatelao*